### PR TITLE
Show number of results found when searching

### DIFF
--- a/gravity-forms-help-scout-search.php
+++ b/gravity-forms-help-scout-search.php
@@ -72,6 +72,8 @@ class PW_GF_HS_Search {
 
 					if( ! searching ) {
 
+						var count = 0;
+
 						// Getting Started
 						$.ajax({
 							url: 'https://docsapi.helpscout.net/v1/search/articles?collectionId=548f1914e4b034fd486247ce&query=' + query,
@@ -85,6 +87,9 @@ class PW_GF_HS_Search {
 								searching = true;
 							},
 							success: function(results) {
+
+								count += results.articles.items.length;
+
 								$.each( results.articles.items, function( key, article ) {
 									html = html + '<li class="article"><a href="' + article.url + '" title="' + article.preview + '">' + article.name + '</a><li>';
 								});
@@ -104,6 +109,9 @@ class PW_GF_HS_Search {
 									searching = true;
 								},
 								success: function(results) {
+
+									count += results.articles.items.length;
+
 									$.each( results.articles.items, function( key, article ) {
 										html = html + '<li class="article"><a href="' + article.url + '" title="' + article.preview + '">' + article.name + '</a><li>';
 									});
@@ -124,6 +132,9 @@ class PW_GF_HS_Search {
 										searching = true;
 									},
 									success: function(results) {
+
+										count += results.articles.items.length;
+
 										$.each( results.articles.items, function( key, article ) {
 											html = html + '<li class="article"><a href="' + article.url + '" title="' + article.preview + '">' + article.name + '</a><li>';
 										});
@@ -131,6 +142,7 @@ class PW_GF_HS_Search {
 								}).done(function() {
 									html = html + '</ul>'
 									//html = html + '<p class="show-contact-form-wrap"><a href="#" id="need-help-contact">Still need help?</a></p>';
+									html = '<span class="results-found">' + count + ' results found . . . </span>' + html;
 									wrap.find('.docs-search-wrap').html( html );
 									paging.show();
 									searching = false;


### PR DESCRIPTION
This PR adds support for showing the number of articles found in search results with a `...` to naturally encourage people to scroll down towards the bottom of the page.

By catering towards the natural instinct of users, we should be able to resolve the problem with customers not understanding that they need to scroll down in order to see the `Open Support Ticket` button.

With this change, we can remove the `To open a support ticket text`.

I have add the results count inside of a span element with a class of `results-found`.
