### PR TITLE
Sanitize the {preview} text.

### DIFF
--- a/gf-hs-search.js
+++ b/gf-hs-search.js
@@ -192,11 +192,26 @@ jQuery( document ).on( 'gform_post_render', function() {
 
 			for ( var key in article ) {
 				if ( article.hasOwnProperty( key ) ) {
-					output = output.replace( '{' + key + '}', article[ key ] );
+					output = output.split( '{' + key + '}' ).join( article[ key ] );
+					output = output.split( '{' + key + '|esc}' ).join( HS_Search.esc_html( article[ key ] ).replace( /\s+/g, ' ' ) );
 				}
 			}
 
 			return output;
+		},
+
+		/**
+		 * Converts a number of HTML entities into their special characters.
+		 *
+		 * Specifically deals with: &, <, >, ", and '.
+		 *
+		 * Not the same thing as WordPress' esc_html() function, just named the same for familiarity.
+		 *
+		 * @param str
+		 * @returns {string}
+		 */
+		esc_html: function ( str ) {
+			return String( str ).replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' ).replace( /"/g, '&quot;' ).replace( /'/, '&#039;' );
 		},
 
 		get_results_found: function ( count ) {

--- a/gravity-forms-help-scout-search.php
+++ b/gravity-forms-help-scout-search.php
@@ -118,7 +118,7 @@ class PW_GF_HS_Search {
 			'template' => array(
 				'wrap_class' => 'docs-search-wrap',
 				'before' => '<ul class="docs-search-results">',
-				'item' => '<li class="article"><a href="{url}" title="{preview}" target="_blank">{name}</a></li>',
+				'item' => '<li class="article"><a href="{url}" title="{preview|esc}&hellip;" target="_blank">{name}</a></li>',
 				'after' => '</ul>',
 				'results_found' => '<span class="{css_class}">{text}</span>',
 			),


### PR DESCRIPTION
- Convert HTML entities so quotes no longer break stuff
- Add a "…" at the end of the preview
- Replace multiple spaces and replace with one (HS strips HTML tags and
leaves whitespace)
- Fix replacing multiple instances of a template tag

@SDavisMedia I think fixing the `{preview}` is preferable to changing
it; that way it's a bugfix rather than a point release. It's easy
enough to modify the template using the
`gf_helpscout_docs_script_settings` filter.

#17 #18